### PR TITLE
CFDecoder: default to dataset coords if not found in given coords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ see `#17 <https://github.com/psyplot/psyplot/pull/17>`__
     with psy.plot.mapplot('file.nc') as sp:
       sp.export('output.png')
 
-  sp will be closed automatically (see commit `ee7415b <https://github.com/psyplot/psyplot/commit/ee7415befce61247b5a08d9cfafab96ceb06f6f8>`__)
+  sp will be closed automatically (see `#18 <https://github.com/psyplot/psyplot/pull/18>`__)
 
 Changed
 -------
@@ -18,6 +18,8 @@ Changed
 * Specifying names in `x`, `y`, `t` and `z` attributes of the `CFDecoder` class
   now means that any other attribute (such as the `coordinates` or `axis` attribute)
   are ignored
+* If a given variable cannot be found in the provided coords to ``CFDecoder.get_variable_by_axis``,
+  we fall back to the ``CFDecoder.ds.coords`` attribute, see `#19 <https://github.com/psyplot/psyplot/pull/19>`__
 
 
 v1.2.1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -346,6 +346,19 @@ class DecoderTest(unittest.TestCase, AlmostArrayEqualMixin):
         # close the dataset
         ds.close()
 
+    def test_get_variable_by_axis_02(self):
+        """Test the :meth:`CFDecoder.get_variable_by_axis` method with missing
+        coordinates, see https://github.com/psyplot/psyplot/pull/19"""
+        fname = os.path.join(bt.test_dir, 'icon_test.nc')
+        with psyd.open_dataset(fname) as ds:
+            ds['ncells'] = ('ncells', np.arange(ds.dims['ncells']))
+            decoder = psyd.CFDecoder(ds)
+            arr = ds.psy['t2m'].psy.isel(ncells=slice(3, 10))
+            del arr['clon']
+            xcoord = decoder.get_variable_by_axis(arr, 'x', arr.coords)
+            self.assertEqual(xcoord.name, 'clon')
+            self.assertEqual(list(xcoord.ncells), list(arr.ncells))
+
     def test_plot_bounds_1d(self):
         """Test to get 2d-interval breaks"""
         x = xr.Variable(('x', ), np.arange(1, 5))


### PR DESCRIPTION
This PR contains a small fix for the `CFDecoder.get_variable_by_axis` method. `decoder.get_variable_by_axis(arr, coords)` will now fall back to `ds.coords` if the variable mentioned in the `coordinate` attribute cannot be found in the given `coords`.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
