### PR TITLE
 bug fix and allow different decoder arguments 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@ v1.2.2
 ======
 Added
 -----
+* ``ArrayList.from_dataset`` (and consecutively all plotmethods) now support
+  different input types for the decoder. You can pass an instance of the
+  ``CFDecoder`` class, a sub class of ``CFDecoder``, or keyword arguments
+  that are used to initialize the decoder,
+  see `#20 <https://github.com/psyplot/psyplot/pull/20>`__
 * `psyplot.data.open_dataset` now decodes grid_mappings attributes,
 see `#17 <https://github.com/psyplot/psyplot/pull/17>`__
 * psyplot projects now support the with syntax, e.g. something like::
@@ -20,6 +25,8 @@ Changed
   are ignored
 * If a given variable cannot be found in the provided coords to ``CFDecoder.get_variable_by_axis``,
   we fall back to the ``CFDecoder.ds.coords`` attribute, see `#19 <https://github.com/psyplot/psyplot/pull/19>`__
+* A bug has been fixed for initializing a ``CFDecoder`` with ``x, y, z`` and
+  ``t`` parameters (see `#20 <https://github.com/psyplot/psyplot/pull/20>`__)
 
 
 v1.2.1

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -3643,7 +3643,6 @@ class ArrayList(list):
         decoder_input = decoder
 
         def get_decoder(arr):
-            print(decoder_input)
             if decoder_input is None:
                 return CFDecoder.get_decoder(base, arr)
             elif isinstance(decoder_input, CFDecoder):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1144,6 +1144,34 @@ class TestArrayList(unittest.TestCase):
         self.assertEqual(len(l[0]), 2)
         self.assertEqual(len(l[1]), 2)
 
+    def test_from_dataset_13_decoder_class(self):
+        ds = xr.Dataset(*self._from_dataset_test_variables)
+
+        class MyDecoder(psyd.CFDecoder):
+            pass
+
+        l = self.list_class.from_dataset(ds, name="v2", decoder=MyDecoder)
+        self.assertIsInstance(l[0].psy.decoder, MyDecoder)
+
+    def test_from_dataset_14_decoder_instance(self):
+        ds = xr.Dataset(*self._from_dataset_test_variables)
+
+        class MyDecoder(psyd.CFDecoder):
+            pass
+
+        decoder = MyDecoder(ds)
+
+        l = self.list_class.from_dataset(ds, name="v2", decoder=decoder)
+        self.assertIs(l[0].psy.decoder, decoder)
+
+    def test_from_dataset_15_decoder_kws(self):
+        ds = xr.Dataset(*self._from_dataset_test_variables)
+
+        l = self.list_class.from_dataset(ds, name="v2",
+                                         decoder=dict(x={'myx'}))
+        self.assertEqual(l[0].psy.decoder.x, {'myx'})
+
+
     def test_array_info(self):
         variables, coords = self._from_dataset_test_variables
         variables['v4'] = variables['v3'].copy()


### PR DESCRIPTION
This PR fixes a bug when speciying x, y, z and t as input arguments to a CFDecoder instance. Furthermore, the `decoder` parameter for the `from_dataset` method now supports different input types,

- `None` to automatically set the decoder
- a `psyplot.data.CFDecoder` instance
- a `psyplot.data.CFDecoder` (sub)class
- keyword arguments as a python `dict`


 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
