### PR TITLE
use name from new_dims when updating array

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ see `#17 <https://github.com/psyplot/psyplot/pull/17>`__
       sp.export('output.png')
 
   sp will be closed automatically (see `#18 <https://github.com/psyplot/psyplot/pull/18>`__)
+* the update to variables with other dimensions works now as well
+  (see `#22 <https://github.com/psyplot/psyplot/pull/22>`__)
 
 Changed
 -------

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -2549,8 +2549,14 @@ class InteractiveArray(InteractiveBase):
             self.method = method
         if 'name' in dims:
             self._new_dims['name'] = dims.pop('name')
-        self._new_dims.update(self.decoder.correct_dims(
-            next(six.itervalues(self.base_variables)), dims))
+        if 'name' in self._new_dims:
+            name = self._new_dims['name']
+            if not isstring(name):
+                name = name[0]  # concatenated array
+            arr = self.base[name]
+        else:
+            arr= next(six.itervalues(self.base_variables))
+        self._new_dims.update(self.decoder.correct_dims(arr, dims))
         InteractiveBase._register_update(
             self, fmt=fmt, replot=replot or bool(self._new_dims), force=force,
             todefault=todefault)

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -2587,6 +2587,10 @@ class InteractiveArray(InteractiveBase):
         if method == 'isel':
             self.idims.update(dims)
             dims = self.idims
+            for dim in set(self.base[name].dims) - set(dims):
+                dims[dim] = slice(None)
+            for dim in set(dims) - set(self.base[name].dims):
+                del dims[dim]
             res = self.base[name].isel(**dims).to_array()
         else:
             self._idims = None
@@ -2640,6 +2644,10 @@ class InteractiveArray(InteractiveBase):
         if method == 'isel':
             self.idims.update(dims)
             dims = self.idims
+            for dim in set(self.base[name].dims) - set(dims):
+                dims[dim] = slice(None)
+            for dim in set(dims) - set(self.base[name].dims):
+                del dims[dim]
             res = self.base[name].isel(**dims)
         else:
             self._idims = None
@@ -2827,6 +2835,14 @@ class InteractiveArray(InteractiveBase):
 
         Notes
         -----
+        When updating to a new array while trying to set the dimensions at the
+        same time, you have to specify the new dimensions via the `dims`
+        parameter, e.g.::
+
+            da.psy.update(name='new_name', dims={'new_dim': 3})
+
+        if ``'new_dim'`` is not yet a dimension of this array
+
         %(InteractiveBase.update.notes)s"""
         dims = dict(dims)
         fmt = dict(fmt)


### PR DESCRIPTION
This PR fixes a bug when updating an array to a variable with more dimensions than the current variable

- [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes

<details>
<summary>Description of changes</summary>

Consider a dataset

```python
>>> ds                                                                                                                                                                                                         
<xarray.Dataset>
Dimensions:  (a: 5, b: 4, c: 3)
Coordinates:
  * a        (a) int64 0 1 2 3 4
  * b        (b) int64 0 1 2 3
  * c        (c) int64 0 1 2
Data variables:
    test1    (a, b) float64 0.0 0.0 0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0 0.0 0.0
    test2    (a, b, c) float64 0.0 0.0 0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0 0.0
```
and a data array from this dataset

```python
>>> da
<xarray.DataArray 'test1' (a: 2, b: 4)>
array([[0., 0., 0., 0.],
       [0., 0., 0., 0.]])
Coordinates:
  * a        (a) int64 1 2
  * b        (b) int64 0 1 2 3
```

You can now update `da` to `test2` although it does not have the same dimensions as the `test1` variable

```python
>>> da.psy.update(name='test2')
>>> da
<xarray.DataArray 'test2' (a: 2, b: 4, c: 3)>
array([[[0., 0., 0.],
        [0., 0., 0.],
        [0., 0., 0.],
        [0., 0., 0.]],

       [[0., 0., 0.],
        [0., 0., 0.],
        [0., 0., 0.],
        [0., 0., 0.]]])
Coordinates:
  * a        (a) int64 1 2
  * b        (b) int64 0 1 2 3
  * c        (c) int64 0 1 2
```

This now took all values for the `c` dimension. You could also do `da.psy.update(name='test2', c=0)` to take a specific slice for the `c` dimension only.

If you update back to `test1`, the c dimension gets deleted

```python
>>> da.psy.update(name='test1')
>>> da
<xarray.DataArray 'test1' (a: 2, b: 4)>
array([[0., 0., 0., 0.],
       [0., 0., 0., 0.]])
Coordinates:
  * a        (a) int64 1 2
  * b        (b) int64 0 1 2 3
```

</details>

Note: this is eventually related to the failure of https://github.com/psyplot/psy-view/pull/21/commits/cfde6c498f54ae52fb2c787c79d857c717834557