### PR TITLE
Fix ci by setting netcdf4, hdf5 and h5py explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,10 @@ workflows:
           exec_environment: << pipeline.parameters.unit-test-executor >>
           setup_env: true
           build_args: "--no-test"
-          env_packages: dask netcdf4 scipy
+          # HACK: force to h5py<3.2 to resolve netcdf4 dependency issue
+          # see https://github.com/h5py/h5py/issues/1880 and
+          # https://github.com/conda-forge/h5py-feedstock/issues/92
+          env_packages: dask netcdf4 scipy h5py<3.2
       - psyplot/test-parallel:
           name: test-xarray-latest
           parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,8 @@ workflows:
           exec_environment: << pipeline.parameters.unit-test-executor >>
           setup_env: true
           build_args: "--no-test"
-          # HACK: force to h5py<3.2 to resolve netcdf4 dependency issue
-          # see https://github.com/h5py/h5py/issues/1880 and
-          # https://github.com/conda-forge/h5py-feedstock/issues/92
-          env_packages: dask netcdf4 scipy h5py<3.2
+          # HACK: force netcdf4 and hdf5 version to resolve dependency issue
+          env_packages: dask netcdf4 scipy netcdf4=1.5.7 h5py=3.4.0 hdf5=1.12.1
       - psyplot/test-parallel:
           name: test-xarray-latest
           parallelism: 2


### PR DESCRIPTION
This PR solves some conda environment issues by specifying a working combination of netcdf5, hdf5 and h5py

 - [x] Tests passed (for all non-documentation changes)

