### PR TITLE
Compatibility fixes for matplotlib 3.5 and python 3.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
     - cmd: endlocal
     - cmd: 'SET PYTHONWARNINGS=ignore:mode:DeprecationWarning:docutils.io:245'
     - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (SET GIT_BRANCH=%APPVEYOR_REPO_BRANCH%)"
-    - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (conda config --add channels psyplot/label/%APPVEYOR_REPO_BRANCH%)"
+    - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (conda config --add channels psyplot/label/%APPVEYOR_REPO_BRANCH:/=-%)"
 
 build: off
 
@@ -37,7 +37,7 @@ test_script:
 deploy_script:
     - cmd: "
         IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (
-            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH% -py %PYTHON_VERSION% ci/conda-recipe
+            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH:/=-% -py %PYTHON_VERSION% ci/conda-recipe
         ) ELSE (
             deploy-conda-recipe -py %PYTHON_VERSION% ci/conda-recipe
         )"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.24
+  psyplot: psyplot/psyplot-ci-orb@1.5.27
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.27
+  psyplot: psyplot/psyplot-ci-orb@1.5.29
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ parameters:
     description: Build the documentation
     type: boolean
     default: true
+  python_version:
+    description: The python version to build
+    type: string
+    default: "3.8"
 
 workflows:
   build-and-test:
@@ -36,8 +40,8 @@ workflows:
           setup_env: << pipeline.parameters.run-tests >>
           build_args: "--no-test"
           build_docs: << pipeline.parameters.build_docs >>
-          # HACK: force netcdf4 and hdf5 version to resolve dependency issue
-          env_packages: dask netcdf4 scipy netcdf4=1.5.7 h5py=3.4.0 hdf5=1.12.1
+          python_version: << pipeline.parameters.python_version >>
+          env_packages: dask netcdf4 scipy
       - psyplot/test-parallel:
           name: test-xarray-latest
           parallelism: 2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,28 @@
+v1.4.1
+======
+Compatibility fixes and minor improvements
+
+Added
+-----
+- An abstract ``convert_coordinate`` method has been implemented for the
+  ``Plotter`` and ``Formatoption`` class that can be used in subclasses to
+  convert coordinates for the required visualization. The default
+  implementation does nothing (see
+  `#39 <https://github.com/psyplot/psyplot/pull/39>`__)
+
+Fixed
+-----
+- the update method now only takes the coordinates that are dimensions in the
+  dataset see `#39 <https://github.com/psyplot/psyplot/pull/39>`__
+
+Changed
+-------
+- loading more than one variables into a ``DataArray`` now first selects the
+  corresponding dimensions, then puts it into a single ``DataArray``. This
+  avoids loading the entire data (see
+  `#39 <https://github.com/psyplot/psyplot/pull/39>`__)
+
+
 v1.4.0
 ======
 Compatibility fixes and LGPL license

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 -----
 - the update method now only takes the coordinates that are dimensions in the
   dataset see `#39 <https://github.com/psyplot/psyplot/pull/39>`__
+- psyplot is now compatible with matplotlib 3.5 and python 3.10
 
 Changed
 -------

--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -38,11 +38,6 @@ test:
     - netcdf4
     - dask
     - scipy
-    # HACK: solve inconsistensies with libwebp
-    # this should be removed when
-    # https://github.com/conda-forge/libwebp-feedstock/issues/26
-    # is solved
-    - libtiff <4.1.0  # [osx]
   source_files:
     - tests
   commands:
@@ -71,5 +66,5 @@ about:
     combines the plotting utilities of matplotlib and the data management of
     the xarray package and integrates them into a software that can be used via
     command-line and via a GUI.
-  doc_url: http://psyplot.github.io
+  doc_url: https://psyplot.github.io
   dev_url: https://github.com/psyplot/psyplot

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -72,8 +72,8 @@ What it is
   visualization. No GUI, independent of it's intuitiveness, can ever beat the
   speed of a scientist that knows a bit of coding and how to use the different
   formatoptions in psyplot.
-- it visualizes :ref:`unstructured grids <psy_maps:gallery_examples_example_ugrid.ipynb>`,
-  such as ICON or UGRID model data
+- it visualizes :ref:`unstructured grids <psyplot_examples:/maps/example_ugrid.ipynb>`,
+  such as ICON_ or UGRID_ model data
 - it automatically decodes CF-conventions
 - it intuitively integrates the structure of netCDF files. So if you often
   work with netCDF files, psyplot might be a good option
@@ -92,6 +92,10 @@ What it is
     them in separate psyplot plugins with it's own formatoptions and
     plotting methods
 - it will always be free and open-source under the LGPL License.
+
+.. _ICON: http://www.mpimet.mpg.de/en/science/models/icon-esm.html
+.. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions/
+
 
 What it is not
 **************

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -93,8 +93,8 @@ What it is
     plotting methods
 - it will always be free and open-source under the LGPL License.
 
-.. _ICON: http://www.mpimet.mpg.de/en/science/models/icon-esm.html
-.. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions/
+.. _ICON: https://mpimet.mpg.de/en/science/modeling-with-icon/icon-configurations
+.. _UGRID: https://ugrid-conventions.github.io/ugrid-conventions/
 
 
 What it is not

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,10 @@ warnings.filterwarnings(
     'ignore', message='Using an implicitly registered datetime converter')
 warnings.filterwarnings(
     'ignore', message=r"\s*The on_mappable_changed function")
+warnings.filterwarnings(
+    'ignore', message=r".+multi-part geometries is deprecated")
+warnings.filterwarnings(
+    'ignore', message=r"\s*The array interface is deprecated")
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,7 @@
 name: psyplot_docs
 channels:
     - local
+    - psyplot/label/__CURRENTBRANCH__
     - psyplot/label/master
     - conda-forge
 dependencies:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,7 @@
 name: psyplot_docs
 channels:
     - local
-    - psyplot/label/__CURRENTBRANCH__
+    - psyplot/label/develop
     - psyplot/label/master
     - conda-forge
 dependencies:

--- a/psyplot/__init__.py
+++ b/psyplot/__init__.py
@@ -123,24 +123,39 @@ def get_versions(requirements=True, key=None):
             }
         }
     """
-    from pkg_resources import iter_entry_points
+    from importlib.metadata import entry_points
     ret = {'psyplot': _get_versions(requirements)}
-    for ep in iter_entry_points(group='psyplot', name='plugin'):
+
+    try:
+        eps = entry_points(group='psyplot', name='plugin')
+    except TypeError:  # python<3.10
+        eps = [ep for ep in entry_points().get('psyplot', [])
+                if ep.name ==  'plugin']
+    for ep in eps:
         if str(ep) in rcParams._plugins:
             logger.debug('Loading entrypoint %s', ep)
-            if key is not None and not key(ep.module_name):
+
+            try:
+                ep.module
+            except AttributeError:  # python<3.10
+                ep.module = ep.pattern.match(ep.value).group("module")
+
+            if key is not None and not key(ep.module):
                 continue
             try:
                 mod = ep.load()
             except (ImportError, ModuleNotFoundError) as e:
-                logger.debug("Could not import %s" % ep, exc_info=True)
-                logger.warning("Could not import %s" % ep)
-            try:
-                ret[str(ep.module_name)] = mod.get_versions(requirements)
-            except AttributeError:
-                ret[str(ep.module_name)] = {
-                    'version': getattr(mod, 'plugin_version',
-                                       getattr(mod, '__version__', ''))}
+                logger.debug("Could not import %s" % (ep, ), exc_info=True)
+                logger.warning("Could not import %s" % (ep, ), exc_info=True)
+            else:
+                try:
+                    ret[str(ep.module)] = mod.get_versions(requirements)
+                except AttributeError:
+                    ret[str(ep.module)] = {
+                        'version': getattr(
+                            mod, 'plugin_version',
+                            getattr(mod, '__version__', ''))
+                        }
     if key is None:
         try:
             import psyplot_gui

--- a/psyplot/__main__.py
+++ b/psyplot/__main__.py
@@ -61,7 +61,7 @@ def main(args=None):
         The parser that has been used from the command line"""
     try:
         from psyplot_gui import get_parser as _get_parser
-    except ImportError:
+    except (ImportError, ModuleNotFoundError) as e:
         logger.debug('Failed to import gui', exc_info=True)
         parser = get_parser(create=False)
         parser.update_arg('output', required=True)

--- a/psyplot/config/rcsetup.py
+++ b/psyplot/config/rcsetup.py
@@ -430,7 +430,7 @@ environment variable."""
 
         Other Parameters
         ----------------
-        ``*args, **kwargs``
+        *args, **kwargs
             Any key-value pair for the initialization of the dictionary
         """
         defaultParams = kwargs.pop('defaultParams', None)

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -3131,7 +3131,13 @@ class InteractiveArray(InteractiveBase):
             # large arrays since it involves a copy of the entire `arr`
             weights = weights * notnull(arr)
             # normalize the weights
-            weights = weights / weights.sum(axis=tuple(map(dims.index, sdims)))
+            if with_dask:
+                summed_weights = weights.sum(
+                    axis=tuple(map(dims.index, sdims)), keepdims=True
+                )
+            else:
+                summed_weights = weights.sum(axis=tuple(map(dims.index, sdims)))
+            weights = weights / summed_weights
         else:
             dims = arr.dims
             coords = arr.isel(

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -3131,7 +3131,7 @@ class InteractiveArray(InteractiveBase):
             # large arrays since it involves a copy of the entire `arr`
             weights = weights * notnull(arr)
             # normalize the weights
-            weights /= weights.sum(axis=tuple(map(dims.index, sdims)))
+            weights = weights / weights.sum(axis=tuple(map(dims.index, sdims)))
         else:
             dims = arr.dims
             coords = arr.isel(

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -3136,7 +3136,9 @@ class InteractiveArray(InteractiveBase):
                     axis=tuple(map(dims.index, sdims)), keepdims=True
                 )
             else:
-                summed_weights = weights.sum(axis=tuple(map(dims.index, sdims)))
+                summed_weights = weights.sum(
+                    axis=tuple(map(dims.index, sdims))
+                )
             weights = weights / summed_weights
         else:
             dims = arr.dims

--- a/psyplot/data.py
+++ b/psyplot/data.py
@@ -3129,10 +3129,9 @@ class InteractiveArray(InteractiveBase):
             weights = broadcast_to(weights / weights.sum(), arr.shape)
             # set nans to zero weigths. This step takes quite a lot of time for
             # large arrays since it involves a copy of the entire `arr`
-            weights *= notnull(arr)
+            weights = weights * notnull(arr)
             # normalize the weights
-            weights /= weights.sum(axis=tuple(map(dims.index, sdims)),
-                                   keepdims=True)
+            weights /= weights.sum(axis=tuple(map(dims.index, sdims)))
         else:
             dims = arr.dims
             coords = arr.isel(

--- a/psyplot/plotter.py
+++ b/psyplot/plotter.py
@@ -752,6 +752,42 @@ class Formatoption(object):
         are removed by the usual :meth:`matplotlib.axes.Axes.clear` method."""
         pass
 
+    @docstrings.get_extended_summary(base="Formatoption.convert_coordinate")
+    @docstrings.get_sections(
+        base="Formatoption.convert_coordinate",
+        sections=["Parameters", "Returns"]
+    )
+    def convert_coordinate(self, coord, *variables):
+        """Convert a coordinate to units necessary for the plot.
+
+        This method takes a single coordinate variable (e.g. the `bounds` of a
+        coordinate, or the coordinate itself) and transforms the units that the
+        plotter requires.
+
+        One might also provide additional `variables` that are supposed to be
+        on the same unit, in case the given `coord` does not specify a `units`
+        attribute. `coord` might be a CF-conform `bounds` variable, and one of
+        the variables might be the corresponding `coordinate`.
+
+        Parameters
+        ----------
+        coord: xr.Variable
+            The variable to transform
+        ``*variables``
+            The variables that are on the same unit as `coord`
+
+        Returns
+        -------
+        xr.Variable
+            The transformed `coord`
+
+        Notes
+        -----
+        By default, this method uses the :meth:`~Plotter.convert_coordinate`
+        method of the :attr:`plotter`.
+        """
+        return self.plotter.convert_coordinate(coord, *variables)
+
 
 class DictFormatoption(Formatoption):
     """
@@ -2434,3 +2470,24 @@ class Plotter(dict):
         """Returns None. May be subclassed to return a projection that
         can be used when creating a subplot"""
         pass
+
+    @docstrings.dedent
+    def convert_coordinate(self, coord, *variables):
+        """Convert a coordinate to units necessary for the plot.
+
+        %(Formatoption.convert_coordinate.summary_ext)s
+
+        Parameters
+        ----------
+        %(Formatoption.convert_coordinate.parameters)s
+
+        Returns
+        -------
+        %(Formatoption.convert_coordinate.returns)s
+
+        Notes
+        -----
+        This method is supposed to be implemented by subclasses. The default
+        implementation by the :class:`Plotter` class does nothing.
+        """
+        return coord

--- a/psyplot/project.py
+++ b/psyplot/project.py
@@ -1634,6 +1634,7 @@ class _ProjectLoader(object):
         subplotpars = d.pop('subplotpars', None)
         if subplotpars is not None:
             subplotpars.pop('validate', None)
+            subplotpars.pop('_validate', None)
             subplotpars = mfig.SubplotParams(**subplotpars)
         if new_fig:
             nums = plt.get_fignums()

--- a/psyplot/utils.py
+++ b/psyplot/utils.py
@@ -226,7 +226,7 @@ def check_key(key, possible_keys, raise_error=True,
     msg: str
         The additional message that shall be used if no close match to
         key is found
-    ``*args,**kwargs``
+    *args, **kwargs
         They are passed to the :func:`difflib.get_close_matches` function
         (i.e. `n` to increase the number of returned similar keys and
         `cutoff` to change the sensibility)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1335,6 +1335,18 @@ class TestArrayList(unittest.TestCase):
                                          decoder=dict(x={'myx'}))
         self.assertEqual(l[0].psy.decoder.x, {'myx'})
 
+    def test_from_dataset_16_default_slice(self):
+        """Test selection with default_slice=0"""
+        variables, coords = self._from_dataset_test_variables
+        ds = xr.Dataset(variables, coords)
+        l = self.list_class.from_dataset(ds, ydim=2, default_slice=0, method=None,
+                                         name=['v0', 'v2'])
+        self.assertEqual(len(l), 2)
+        self.assertEqual(set(l.names), {'v0', 'v2'})
+        for arr in l:
+            self.assertEqual(arr.ydim, 2,
+                             msg="Wrong ydim slice for " + arr.name)
+
 
     def test_array_info(self):
         variables, coords = self._from_dataset_test_variables


### PR DESCRIPTION
This PR bundles multiple PRs to make a new release for psyplot

<details>
<summary>Changelog</summary>

Added
-----
-   An abstract `convert_coordinate` method has been implemented for the
    `Plotter` and `Formatoption` class that can be used in subclasses to
    convert coordinates for the required visualization. The default
    implementation does nothing (see #39)

Fixed
-----
-   the update method now only takes the coordinates that are dimensions
    in the dataset, see #39
-   psyplot is now compatible with matplotlib 3.5 and python 3.10

Changed
-------
-   loading more than one variables into a `DataArray` now first selects
    the corresponding dimensions, then puts it into a single
    `DataArray`. This avoids loading the entire data (see #39)

</details>

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
