### PR TITLE
52 fileexistserror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.31
+  psyplot: psyplot/psyplot-ci-orb@1.5.32
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/psyplot/config/rcsetup.py
+++ b/psyplot/config/rcsetup.py
@@ -1025,7 +1025,7 @@ def get_configdir(name='psyplot', env_key='PSYPLOTCONFIGDIR'):
         p = os.path.join(h, '.' + name)
 
     if not os.path.exists(p):
-        os.makedirs(p)
+        os.makedirs(p, exist_ok=True)
     return p
 
 

--- a/psyplot/project.py
+++ b/psyplot/project.py
@@ -1163,7 +1163,7 @@ class Project(ArrayList):
         if pack and fname is not None:
             target_dir = os.path.dirname(fname)
             if not os.path.exists(target_dir):
-                os.makedirs(target_dir)
+                os.makedirs(target_dir, exist_ok=True)
 
             def tmp_it():
                 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
When creating directories, this fix now always adds the parameter `exists_ok=True` to the call of `os.makedirs`

 - [ ] Fully documented, including `CHANGELOG.rst` for all changes

@schlunma, it would be great if you could verify that this fix closes #52